### PR TITLE
added option to append webp ext

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,11 @@ module.exports = function (opts) {
 					return;
 				}
 
-				file.path = replaceExt(file.path, '.webp');
+				if (opts.appendExtension) {
+					file.path += '.webp';
+				} else {
+					file.path = replaceExt(file.path, '.webp');
+				}
 				file.contents = buf;
 				cb(null, file);
 			});

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,13 @@ Default: `false`
 
 Encode images losslessly.
 
+#### options.appendExtension
+
+Type: `boolean`
+Default: `false`
+
+If true append the `.webp` extension instead of replacing it to the original one.
+
 
 ## License
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ var test = require('ava');
 var imageminWebp = require('../');
 
 test('convert an image into a WebP', function (t) {
-	t.plan(3);
+	t.plan(4);
 
 	read(path.join(__dirname, 'fixtures/test.png'), function (err, file) {
 		t.assert(!err, err);
@@ -20,6 +20,26 @@ test('convert an image into a WebP', function (t) {
 			t.assert(data.contents.length < size, data.contents.length);
 			t.assert(isWebP(data.contents));
 			t.assert(path.extname(data.path) === '.webp', path.extname(data.path));
+		});
+
+		stream.end(file);
+	});
+});
+
+
+test('convert an image into a WebP and append ext', function (t) {
+	t.plan(4);
+
+	read(path.join(__dirname, 'fixtures/test.png'), function (err, file) {
+		t.assert(!err, err);
+
+		var stream = imageminWebp({appendExtension: true})();
+		var size = file.contents.length;
+
+		stream.on('data', function (data) {
+			t.assert(data.contents.length < size, data.contents.length);
+			t.assert(isWebP(data.contents));
+			t.assert(path.basename(data.path) === 'test.png.webp', path.basename(data.path));
 		});
 
 		stream.end(file);


### PR DESCRIPTION
I have the needing to append the webp extension to the file parsed, so I have added a new option to make it possible.

I need it to better configure nginx serving of images, but it can be useful also if you have one png and one jpg with the same basename but with different images inside.