### PR TITLE
Add `metadata` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ module.exports = opts => buf => {
 		args.push('-resize', opts.resize.width, opts.resize.height);
 	}
 
+	if (opts.metadata) {
+		args.push('-metadata', Array.isArray(opts.metadata) ? opts.metadata.join(',') : opts.metadata);
+	}
+
 	args.push('-o', execBuffer.output, execBuffer.input);
 
 	return execBuffer({

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,13 @@ Type: `Object { width: number, height: number }`
 
 Resize the image. Happens after `crop`.
 
+##### metadata
+
+Type: `string | string[]`<br>
+Default: `none`
+
+A list of metadata to copy from the input to the output if present. Valid values: `all`, `none`, `exif`, `icc`, `xmp`.
+
 #### buffer
 
 Type: `Buffer`

--- a/readme.md
+++ b/readme.md
@@ -124,9 +124,10 @@ Resize the image. Happens after `crop`.
 ##### metadata
 
 Type: `string | string[]`<br>
-Default: `none`
+Default: `none`<br>
+Values: `all` `none` `exif` `icc` `xmp`
 
-A list of metadata to copy from the input to the output if present. Valid values: `all`, `none`, `exif`, `icc`, `xmp`.
+A list of metadata to copy from the input to the output if present.
 
 #### buffer
 


### PR DESCRIPTION
This can be done using the -metadata cwebp command line argument. I need this to keep the ICC profile, otherwise the colors become different after conversion to webp.