### PR TITLE
docs: fix sns default value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Set target size in bytes.
 ##### sns
 
 Type: `number`<br>
-Default: `80`
+Default: `50`
 
 Set the amplitude of spatial noise shaping between `0` and `100`.
 


### PR DESCRIPTION
CC @1000ch

After v7.0.0 update, got the different image output with the same options.

https://github.com/antongolub/imagemin-webp/commit/90977fef41dd09d78d116bb825f71fb97149d414 brings `cwebp-bin@6` which uses https://github.com/imagemin/cwebp-bin/commit/7f4933384cfa49b04310f80da4f5cb1a42a86b63 `cwebp-1.2.1` which now uses [`sns=50` as default](https://developers.google.com/speed/webp/docs/cwebp)

So the docs should be updated.