### PR TITLE
Bump cwebp-bin@^8.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         node-version:
           - 16
           - 14
-          - 12
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		}
 	],
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": "^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -41,7 +41,7 @@
 		"webp"
 	],
 	"dependencies": {
-		"cwebp-bin": "^7.0.1",
+		"cwebp-bin": "^8.0.0",
 		"exec-buffer": "^3.2.0",
 		"is-cwebp-readable": "^3.0.0"
 	},


### PR DESCRIPTION
Only relevant breaking change of `cwebp-bin@^8.0.0` is dropping Node 12: https://github.com/imagemin/cwebp-bin/releases/tag/v8.0.0, which has been EOL anyway since April 2022: https://github.com/nodejs/release#end-of-life-releases

